### PR TITLE
fix problem with top-level field names

### DIFF
--- a/plugin/protoc-gen-lua
+++ b/plugin/protoc-gen-lua
@@ -148,7 +148,7 @@ class Env(object):
             node = self.lookup_name(type_name)
         except:
             # if the child doesn't be founded, it must be in this file
-            return type_name[len('.'.join(self.package)) + 2:]
+            return type_name[len('.'.join(self.package)) + 1:]
         if node.filename != self.filename:
             return node.filename + '_pb.' + node.get_local_name()
         return node.get_local_name()


### PR DESCRIPTION
I tried to add an address to person, thus:

```
message Person {
  required int32 id = 1;
  required string name = 2;
  optional string email = 3;
  repeated Address addresses = 4;

  extensions 10 to max;
}

message Address {
  required string street = 1;
}
```

running protoc on this resulted in a problem, because the `addresses` field in the generated code looked thus; notice the `message_type` is wrong.

``` lua
PERSON_ADDRESSES_FIELD.name = "addresses"
PERSON_ADDRESSES_FIELD.full_name = ".Person.addresses"
PERSON_ADDRESSES_FIELD.number = 4
PERSON_ADDRESSES_FIELD.index = 3
PERSON_ADDRESSES_FIELD.label = 3
PERSON_ADDRESSES_FIELD.has_default_value = false
PERSON_ADDRESSES_FIELD.default_value = {}
PERSON_ADDRESSES_FIELD.message_type = DDRESS
PERSON_ADDRESSES_FIELD.type = 11
PERSON_ADDRESSES_FIELD.cpp_type = 10
```

The problem seem to be that top-level message types get generated wrong, and this patch fixes that.

I have not done extensive testing, so the fix may cause other problems.
