### PR TITLE
fix import other proto bug, without changing the xxx_pb variable 

### DIFF
--- a/plugin/protoc-gen-lua
+++ b/plugin/protoc-gen-lua
@@ -282,7 +282,7 @@ def code_gen_enum(enum_desc, env):
     env.exit()
     return obj_name
 
-def code_gen_field(index, field_desc, env):
+def code_gen_field(index, field_desc, env, includes):
     full_name = env.get_local_name() + '.' + field_desc.name
     obj_name = full_name.upper().replace('.', '_') + '_FIELD'
     env.descriptor.append(
@@ -316,7 +316,9 @@ def code_gen_field(index, field_desc, env):
         context('.default_value = %s\n' % default_value)
 
     if field_desc.HasField('type_name'):
-        type_name = env.get_ref_name(field_desc.type_name).upper().replace('.', '_')
+        type_name = env.get_ref_name(field_desc.type_name)
+        if not type_name.split('.')[0] in [filename+"_pb" for filename in includes]:
+            type_name = type_name.upper().replace('.', '_')
         if field_desc.type == FDP.TYPE_MESSAGE:
             context('.message_type = %s\n' % type_name)
         else:
@@ -333,7 +335,7 @@ def code_gen_field(index, field_desc, env):
     env.context.append(context.getvalue())
     return obj_name
 
-def code_gen_message(message_descriptor, env, containing_type = None):
+def code_gen_message(message_descriptor, env, includes, containing_type = None):
     env.enter(message_descriptor.name)
     full_name = env.get_local_name()
     obj_name = full_name.upper().replace('.', '_')
@@ -347,7 +349,7 @@ def code_gen_message(message_descriptor, env, containing_type = None):
 
     nested_types = []
     for msg_desc in message_descriptor.nested_type:
-        msg_name = code_gen_message(msg_desc, env, obj_name)
+        msg_name = code_gen_message(msg_desc, env, includes, obj_name)
         nested_types.append(msg_name)
     context('.nested_types = {%s}\n' % ', '.join(nested_types))
 
@@ -358,7 +360,7 @@ def code_gen_message(message_descriptor, env, containing_type = None):
 
     fields = []
     for i, field_desc in enumerate(message_descriptor.field):
-        fields.append(code_gen_field(i, field_desc, env))
+        fields.append(code_gen_field(i, field_desc, env, includes))
 
     context('.fields = {%s}\n' % ', '.join(fields))
     if len(message_descriptor.extension_range) > 0:
@@ -368,7 +370,7 @@ def code_gen_message(message_descriptor, env, containing_type = None):
 
     extensions = []
     for i, field_desc in enumerate(message_descriptor.extension):
-        extensions.append(code_gen_field(i, field_desc, env))
+        extensions.append(code_gen_field(i, field_desc, env, includes))
     context('.extensions = {%s}\n' % ', '.join(extensions))
 
     if containing_type:
@@ -404,7 +406,7 @@ def code_gen_file(proto_file, env, is_gen):
                                               enum_value.number))
 
     for msg_desc in proto_file.message_type:
-        code_gen_message(msg_desc, env)
+        code_gen_message(msg_desc, env, includes)
 
     if is_gen:
         lua = Writer()

--- a/protobuf/containers.lua
+++ b/protobuf/containers.lua
@@ -24,7 +24,8 @@ module "containers"
 
 local _RCFC_meta = {
     add = function(self)
-        local value = self._message_descriptor._concrete_class()
+        local message_descriptor = self._message_descriptor
+        local value = (message_descriptor._concrete_class and message_descriptor._concrete_class()) or message_descriptor()
         local listener = self._listener
         rawset(self, #self + 1, value)
         value:_SetListener(listener)

--- a/protobuf/protobuf.lua
+++ b/protobuf/protobuf.lua
@@ -285,7 +285,7 @@ local function _DefaultValueConstructorForField(field)
     if field.cpp_type == FieldDescriptor.CPPTYPE_MESSAGE then
         local message_type = field.message_type
         return function (message)
-            result = message_type._concrete_class()
+            result = (message_type._concrete_class and message_type._concrete_class()) or message_type()
             result._SetListener(message._listener_for_children)
             return result
         end
@@ -360,7 +360,7 @@ local function _AddPropertiesForNonRepeatedCompositeField(field, message_meta)
     message_meta._getter[property_name] = function(self)
         local field_value = self._fields[field]
         if field_value == nil then
-            field_value = message_type._concrete_class()
+            field_value = (message_type._concrete_class and message_type._concrete_class()) or message_type()
             field_value:_SetListener(self._listener_for_children)
             
             self._fields[field] = field_value


### PR DESCRIPTION
an error occurs when you want to use other message type from another proto file, 

> [string "protobuf.lua"]:363: attempt to index upvalue 'message_type' (a nil value)

e.g.
mail.proto:

``` protobuf
    import "reward.proto";
    package mail;

    message Mail
    {
        optional uint32 id = 1;  
        optional reward.Reward reward = 2;
    }
```

reward.proto:

``` protobuf
    package reward; 
    message Reward
    {
        optional uint32 money = 1;
    }
```

test.lua:

``` lua
    -- sending --
    local sendMail = mail_pb.Mail()
    sendMail.id = 12
    local reward = sendMail.reward
    reward.money = 30
    printf(sendMail)

    -- receiving--
    local recvMail = mail_pb.Mail()
    recvMail:ParseFromString(sendMail:SerializeToString())
    printf(recvMail)
```

The same thing happens when using repeated instead of optional.

> [string "containers.lua"]:27: attempt to call field '_concrete_class' (a nil value)

The reason is that `mail_pb.lua` generated by protoc-gen-lua doesn't consider the situation of other proto msg type. The message_type is nil.

some guy has fixed this bug by putting the REWARD table to XXX_pb variable. But I offer another method without changing XXX_pb.

you can choose whether is more fit considering your program structure.

Thank you for reading.
