### PR TITLE
fix bug for nested message

### DIFF
--- a/plugin/protoc-gen-lua
+++ b/plugin/protoc-gen-lua
@@ -148,7 +148,7 @@ class Env(object):
             node = self.lookup_name(type_name)
         except:
             # if the child doesn't be founded, it must be in this file
-            return type_name[len('.'.join(self.package)) + 1:]
+            return type_name[len('.'.join(self.package)) + 2:]
         if node.filename != self.filename:
             return node.filename + '_pb.' + node.get_local_name()
         return node.get_local_name()


### PR DESCRIPTION
```
package example;
message A{
    optional B b = 1;
}
message B{
    optional int32 id;
}
```
B is defined after A, then get_ref_name return wrong name '.B'