### PR TITLE
lua local-var count limitation, enum default value, cocoslua option

### DIFF
--- a/plugin/protoc-gen-lua
+++ b/plugin/protoc-gen-lua
@@ -21,6 +21,14 @@ _packages = {}
 _files = {}
 _message = {}
 
+''' break limitation of local-variable count by gathering all variables within a local aux table '''
+_auxtable_ = "_"
+luasymbol = lambda protoName : "%s.%s" % (_auxtable_, protoName)
+
+''' make default enum value symbols from same or imported modules '''
+importedEnumValue = lambda typename, value : typename[:typename.rfind(".") + 1] + value
+containedEnumValue = lambda typename, value: '%s_%s_ENUM.number' % (typename, value.upper())
+
 FDP = plugin_pb2.descriptor_pb2.FieldDescriptorProto
 
 if sys.platform == "win32":
@@ -250,10 +258,10 @@ def code_gen_enum_item(index, enum_value, env):
     full_name = env.get_local_name() + '.' + enum_value.name
     obj_name = full_name.upper().replace('.', '_') + '_ENUM'
     env.descriptor.append(
-        "local %s = protobuf.EnumValueDescriptor();\n"% obj_name
+        "%s = protobuf.EnumValueDescriptor();\n"% luasymbol(obj_name)
     )
 
-    context = Writer(obj_name)
+    context = Writer(luasymbol(obj_name))
     context('.name = "%s"\n' % enum_value.name)
     context('.index = %d\n' % index)
     context('.number = %d\n' % enum_value.number)
@@ -266,30 +274,30 @@ def code_gen_enum(enum_desc, env):
     full_name = env.get_local_name()
     obj_name = full_name.upper().replace('.', '_')
     env.descriptor.append(
-        "local %s = protobuf.EnumDescriptor();\n"% obj_name
+        "%s = protobuf.EnumDescriptor();\n"% luasymbol(obj_name)
     )
 
-    context = Writer(obj_name)
+    context = Writer(luasymbol(obj_name))
     context('.name = "%s"\n' % enum_desc.name)
     context('.full_name = "%s"\n' % env.get_global_name())
 
     values = []
     for i, enum_value in enumerate(enum_desc.value):
-        values.append(code_gen_enum_item(i, enum_value, env))
+        values.append(luasymbol(code_gen_enum_item(i, enum_value, env)))
     context('.values = {%s}\n' % ','.join(values))
 
     env.context.append(context.getvalue())
     env.exit()
     return obj_name
 
-def code_gen_field(index, field_desc, env):
+def code_gen_field(index, field_desc, env,includes):
     full_name = env.get_local_name() + '.' + field_desc.name
     obj_name = full_name.upper().replace('.', '_') + '_FIELD'
     env.descriptor.append(
-        "local %s = protobuf.FieldDescriptor();\n"% obj_name
+        "%s = protobuf.FieldDescriptor();\n"% luasymbol(obj_name)
     )
 
-    context = Writer(obj_name)
+    context = Writer(luasymbol(obj_name))
 
     context('.name = "%s"\n' % field_desc.name)
     context('.full_name = "%s"\n' % (
@@ -298,11 +306,29 @@ def code_gen_field(index, field_desc, env):
     context('.index = %d\n' % index)
     context('.label = %d\n' % field_desc.label)
 
+    finalTypeName = None
+    enumValueSolver = importedEnumValue
+
+    if field_desc.HasField('type_name'):
+        #type_name = env.get_ref_name(field_desc.type_name).upper().replace('.', '_')
+        type_name = env.get_ref_name(field_desc.type_name)
+        if not type_name.split('.')[0] in [filename+"_pb" for filename in includes]:
+            type_name = luasymbol(type_name.upper().replace(".","_"))
+            enumValueSolver = containedEnumValue
+        
+        finalTypeName = type_name
+        if field_desc.type == FDP.TYPE_MESSAGE:
+            context('.message_type = %s\n' % type_name)
+        else:
+            context('.enum_type = %s\n' % type_name)
+
     if field_desc.HasField("default_value"):
         context('.has_default_value = true\n')
         value = field_desc.default_value
         if field_desc.type == FDP.TYPE_STRING:
             context('.default_value = "%s"\n'%value)
+        elif field_desc.type == FDP.TYPE_ENUM:
+            context('.default_value = %s\n'% enumValueSolver(finalTypeName, value))
         else:
             context('.default_value = %s\n'%value)
     else:
@@ -315,17 +341,10 @@ def code_gen_field(index, field_desc, env):
             default_value = DEFAULT_VALUE[field_desc.type]
         context('.default_value = %s\n' % default_value)
 
-    if field_desc.HasField('type_name'):
-        type_name = env.get_ref_name(field_desc.type_name).upper().replace('.', '_')
-        if field_desc.type == FDP.TYPE_MESSAGE:
-            context('.message_type = %s\n' % type_name)
-        else:
-            context('.enum_type = %s\n' % type_name)
-
     if field_desc.HasField('extendee'):
         type_name = env.get_ref_name(field_desc.extendee)
         env.register.append(
-            "%s.RegisterExtension(%s)\n" % (type_name, obj_name)
+            "%s.RegisterExtension(%s)\n" % (type_name, luasymbol(obj_name))
         )
 
     context('.type = %d\n' % field_desc.type)
@@ -333,32 +352,33 @@ def code_gen_field(index, field_desc, env):
     env.context.append(context.getvalue())
     return obj_name
 
-def code_gen_message(message_descriptor, env, containing_type = None):
+def code_gen_message(message_descriptor, env,includes, containing_type = None):
     env.enter(message_descriptor.name)
     full_name = env.get_local_name()
     obj_name = full_name.upper().replace('.', '_')
     env.descriptor.append(
-        "local %s = protobuf.Descriptor();\n"% obj_name
+        "%s = protobuf.Descriptor();\n"% luasymbol(obj_name)
     )
 
-    context = Writer(obj_name)
+    context = Writer(luasymbol(obj_name))
     context('.name = "%s"\n' % message_descriptor.name)
     context('.full_name = "%s"\n' % env.get_global_name())
 
     nested_types = []
     for msg_desc in message_descriptor.nested_type:
-        msg_name = code_gen_message(msg_desc, env, obj_name)
-        nested_types.append(msg_name)
+        #msg_name = code_gen_message(msg_desc, env, obj_name)
+        msg_name = code_gen_message(msg_desc,env,includes,obj_name)
+        nested_types.append(luasymbol(msg_name))
     context('.nested_types = {%s}\n' % ', '.join(nested_types))
 
     enums = []
     for enum_desc in message_descriptor.enum_type:
-        enums.append(code_gen_enum(enum_desc, env))
+        enums.append(luasymbol(code_gen_enum(enum_desc, env)))
     context('.enum_types = {%s}\n' % ', '.join(enums))
 
     fields = []
     for i, field_desc in enumerate(message_descriptor.field):
-        fields.append(code_gen_field(i, field_desc, env))
+        fields.append(luasymbol(code_gen_field(i, field_desc, env,includes)))
 
     context('.fields = {%s}\n' % ', '.join(fields))
     if len(message_descriptor.extension_range) > 0:
@@ -368,14 +388,14 @@ def code_gen_message(message_descriptor, env, containing_type = None):
 
     extensions = []
     for i, field_desc in enumerate(message_descriptor.extension):
-        extensions.append(code_gen_field(i, field_desc, env))
+        extensions.append(luasymbol(code_gen_field(i, field_desc, env,includes)))
     context('.extensions = {%s}\n' % ', '.join(extensions))
 
     if containing_type:
-        context('.containing_type = %s\n' % containing_type)
+        context('.containing_type = %s\n' % luasymbol(containing_type))
 
     env.message.append('%s = protobuf.Message(%s)\n' % (full_name,
-                                                        obj_name))
+                                                        luasymbol(obj_name)))
 
     env.context.append(context.getvalue())
     env.exit()
@@ -404,7 +424,7 @@ def code_gen_file(proto_file, env, is_gen):
                                               enum_value.number))
 
     for msg_desc in proto_file.message_type:
-        code_gen_message(msg_desc, env)
+        code_gen_message(msg_desc, env,includes)
 
     if is_gen:
         lua = Writer()
@@ -412,7 +432,9 @@ def code_gen_file(proto_file, env, is_gen):
         lua('local protobuf = require "protobuf"\n')
         for i in includes:
             lua('local %s_pb = require("%s_pb")\n' % (i, i))
+        lua('pcall(function() cc.exports.%s_pb={} end) -- for cocoslua\n' % env.filename) # for cocoslua
         lua("module('%s_pb')\n" % env.filename)
+        lua('local %s = {}\n' % _auxtable_)
 
         lua('\n\n')
         map(lua, env.descriptor)

--- a/plugin/protoc-gen-lua
+++ b/plugin/protoc-gen-lua
@@ -256,12 +256,12 @@ DEFAULT_VALUE = {
 
 def code_gen_enum_item(index, enum_value, env):
     full_name = env.get_local_name() + '.' + enum_value.name
-    obj_name = full_name.upper().replace('.', '_') + '_ENUM'
+    obj_name = luasymbol(full_name.upper().replace('.', '_') + '_ENUM')
     env.descriptor.append(
-        "%s = protobuf.EnumValueDescriptor();\n"% luasymbol(obj_name)
+        "%s = protobuf.EnumValueDescriptor();\n"% obj_name
     )
 
-    context = Writer(luasymbol(obj_name))
+    context = Writer(obj_name)
     context('.name = "%s"\n' % enum_value.name)
     context('.index = %d\n' % index)
     context('.number = %d\n' % enum_value.number)
@@ -272,18 +272,18 @@ def code_gen_enum_item(index, enum_value, env):
 def code_gen_enum(enum_desc, env):
     env.enter(enum_desc.name)
     full_name = env.get_local_name()
-    obj_name = full_name.upper().replace('.', '_')
+    obj_name = luasymbol(full_name.upper().replace('.', '_'))
     env.descriptor.append(
-        "%s = protobuf.EnumDescriptor();\n"% luasymbol(obj_name)
+        "%s = protobuf.EnumDescriptor();\n"% obj_name
     )
 
-    context = Writer(luasymbol(obj_name))
+    context = Writer(obj_name)
     context('.name = "%s"\n' % enum_desc.name)
     context('.full_name = "%s"\n' % env.get_global_name())
 
     values = []
     for i, enum_value in enumerate(enum_desc.value):
-        values.append(luasymbol(code_gen_enum_item(i, enum_value, env)))
+        values.append(code_gen_enum_item(i, enum_value, env))
     context('.values = {%s}\n' % ','.join(values))
 
     env.context.append(context.getvalue())
@@ -292,12 +292,12 @@ def code_gen_enum(enum_desc, env):
 
 def code_gen_field(index, field_desc, env,includes):
     full_name = env.get_local_name() + '.' + field_desc.name
-    obj_name = full_name.upper().replace('.', '_') + '_FIELD'
+    obj_name = luasymbol(full_name.upper().replace('.', '_') + '_FIELD')
     env.descriptor.append(
-        "%s = protobuf.FieldDescriptor();\n"% luasymbol(obj_name)
+        "%s = protobuf.FieldDescriptor();\n"% obj_name
     )
 
-    context = Writer(luasymbol(obj_name))
+    context = Writer(obj_name)
 
     context('.name = "%s"\n' % field_desc.name)
     context('.full_name = "%s"\n' % (
@@ -344,7 +344,7 @@ def code_gen_field(index, field_desc, env,includes):
     if field_desc.HasField('extendee'):
         type_name = env.get_ref_name(field_desc.extendee)
         env.register.append(
-            "%s.RegisterExtension(%s)\n" % (type_name, luasymbol(obj_name))
+            "%s.RegisterExtension(%s)\n" % (type_name, obj_name)
         )
 
     context('.type = %d\n' % field_desc.type)
@@ -355,12 +355,12 @@ def code_gen_field(index, field_desc, env,includes):
 def code_gen_message(message_descriptor, env,includes, containing_type = None):
     env.enter(message_descriptor.name)
     full_name = env.get_local_name()
-    obj_name = full_name.upper().replace('.', '_')
+    obj_name = luasymbol(full_name.upper().replace('.', '_'))
     env.descriptor.append(
-        "%s = protobuf.Descriptor();\n"% luasymbol(obj_name)
+        "%s = protobuf.Descriptor();\n"% obj_name
     )
 
-    context = Writer(luasymbol(obj_name))
+    context = Writer(obj_name)
     context('.name = "%s"\n' % message_descriptor.name)
     context('.full_name = "%s"\n' % env.get_global_name())
 
@@ -368,17 +368,17 @@ def code_gen_message(message_descriptor, env,includes, containing_type = None):
     for msg_desc in message_descriptor.nested_type:
         #msg_name = code_gen_message(msg_desc, env, obj_name)
         msg_name = code_gen_message(msg_desc,env,includes,obj_name)
-        nested_types.append(luasymbol(msg_name))
+        nested_types.append(msg_name)
     context('.nested_types = {%s}\n' % ', '.join(nested_types))
 
     enums = []
     for enum_desc in message_descriptor.enum_type:
-        enums.append(luasymbol(code_gen_enum(enum_desc, env)))
+        enums.append(code_gen_enum(enum_desc, env))
     context('.enum_types = {%s}\n' % ', '.join(enums))
 
     fields = []
     for i, field_desc in enumerate(message_descriptor.field):
-        fields.append(luasymbol(code_gen_field(i, field_desc, env,includes)))
+        fields.append(code_gen_field(i, field_desc, env,includes))
 
     context('.fields = {%s}\n' % ', '.join(fields))
     if len(message_descriptor.extension_range) > 0:
@@ -388,14 +388,14 @@ def code_gen_message(message_descriptor, env,includes, containing_type = None):
 
     extensions = []
     for i, field_desc in enumerate(message_descriptor.extension):
-        extensions.append(luasymbol(code_gen_field(i, field_desc, env,includes)))
+        extensions.append(code_gen_field(i, field_desc, env,includes))
     context('.extensions = {%s}\n' % ', '.join(extensions))
 
     if containing_type:
-        context('.containing_type = %s\n' % luasymbol(containing_type))
+        context('.containing_type = %s\n' % containing_type)
 
     env.message.append('%s = protobuf.Message(%s)\n' % (full_name,
-                                                        luasymbol(obj_name)))
+                                                        obj_name))
 
     env.context.append(context.getvalue())
     env.exit()

--- a/plugin/protoc-gen-lua.bat
+++ b/plugin/protoc-gen-lua.bat
@@ -1,0 +1,1 @@
+@python "%~dp0protoc-gen-lua"


### PR DESCRIPTION
use an aux table as container of all local-variables to break lua's local-variable count limitation;
also solve enum default values; addtionally, adds cocoslua compatibility option.
